### PR TITLE
{} not longer supported for array since php 7.4

### DIFF
--- a/plxMyCapchaImage.php
+++ b/plxMyCapchaImage.php
@@ -73,7 +73,7 @@ class plxMyCapchaImage extends plxPlugin {
 		$chars = '23456789abcdefghjklmnpqrstuvwxyz'; // Certains caractères ont été enlevés car ils prêtent à confusion
 		$rand_str = '';
 		for ($i=0; $i<$length; $i++) {
-			$rand_str .= $chars{ mt_rand( 0, strlen($chars)-1 ) };
+			$rand_str .= $chars[ mt_rand( 0, strlen($chars)-1 ) ];
 		}
 		return strtolower($rand_str);
 	}


### PR DESCRIPTION
Hello,
I updated the main file to change {} with [] because of PHP error :
$rand_str .= $chars[ mt_rand( 0, strlen($chars)-1 ) ];

Tested with pluxml 5.8.9 and php 8.1
Thanks for the plugin, it's very useful
Lou